### PR TITLE
Make parallel an optional feature to support WASM environments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,11 @@ edition = "2018"
 [dependencies]
 ark-bls12-377 = { version = "0.3" }
 ark-serialize = { version = "0.3", features = [ "derive" ] }
-ark-ff = { version = "0.3", features = [ "std", "parallel"] }
-ark-ec = { version = "0.3", features = [ "std", "parallel"] }
-ark-std = { version = "0.3", features = ["std"] }
+ark-ff = { version = "0.3", features = [ "std" ] }
+ark-ec = { version = "0.3", features = [ "std" ] }
+ark-std = { version = "0.3", features = [ "std" ] }
 ark-ed-on-bw6-761 = { version = "0.3" }
-ark-crypto-primitives = { version = "0.3", features = ["parallel"] }
+ark-crypto-primitives = { version = "0.3" }
 
 # other deps
 rand = "0.8.4"
@@ -50,6 +50,9 @@ crate-type = ["lib", "staticlib"]
 default = [ "compat" ]
 test-helpers = []
 compat = []
+
+# Enable parallel computation. Cannot be used with WASM.
+parallel = ["ark-ec/parallel", "ark-ff/parallel", "ark-crypto-primitives/parallel"]
 
 [[bench]]
 name = "batch_bls"


### PR DESCRIPTION
### Description

Currently, `parallel` is included as a required feature on arkworks dependencies. Threading is not
supported in WASM environments, so this results in a panic if any code path is encountered that
utilizes multithreading.

This PR puts those features behind a `parallel` flag on this library.
